### PR TITLE
fix: .nimotsuファイルが無い場合作成するようにした

### DIFF
--- a/list/io.go
+++ b/list/io.go
@@ -22,6 +22,12 @@ func (l *List) Save() error {
 // Load ファイルから読込
 func (l *List) Load() error {
 	path := getSaveFilePath()
+	if isNotExist(path) {
+		if err := createFile(path); err != nil {
+			return err
+		}
+	}
+
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
@@ -37,4 +43,17 @@ func getSaveFilePath() string {
 	}
 
 	return filepath.Join(homeDir, filename)
+}
+
+func isNotExist(path string) bool {
+	_, err := os.Stat(path)
+	return os.IsNotExist(err)
+}
+
+func createFile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	return f.Close()
 }


### PR DESCRIPTION
おはようございます🌞！

こちらのツールを使ってみたかったのですが、.nimotsuファイルが無いとエラーになるようなので、ファイルの存在チェックと作成処理を入れてみました！
（ユーザーに.nimotsuファイルを直接作ってもらう意図があるのかもですが）

go fmtとgo testは実行しました🙇

- before
![before](https://user-images.githubusercontent.com/41510086/206820499-4caa7736-954d-49a2-ac9f-8ac8566101a1.png)

- after
![after](https://user-images.githubusercontent.com/41510086/206820676-4eed7031-dd42-4173-93e3-85ddeff2dba8.png)


よろしくお願いします。